### PR TITLE
Protfolio auth

### DIFF
--- a/src/Portfolio/portfolioFormatter.py
+++ b/src/Portfolio/portfolioFormatter.py
@@ -482,7 +482,7 @@ class PortfolioFormatter:
     # -------------------------
     # Public API
     # -------------------------
-    def get_portfolio_data(self, include_hidden: bool = False) -> Dict[str, Any]:
+    def get_portfolio_data(self, user_id: int, include_hidden: bool = False) -> Dict[str, Any]:
         """
         Get complete portfolio data (includes an embedded summary).
 
@@ -495,7 +495,7 @@ class PortfolioFormatter:
                 'generated_at': iso str
             }
         """
-        projects = self.db.get_all_projects(include_hidden=include_hidden)
+        projects = self.db.get_all_projects(include_hidden=include_hidden, user_id=user_id)
 
         # print("DEBUG projects:", len(projects))
         # if projects:
@@ -529,6 +529,7 @@ class PortfolioFormatter:
 
     def get_filtered_projects(
         self,
+        user_id: int,
         project_type: Optional[str] = None,
         search: Optional[str] = None,
         min_importance: Optional[float] = None,
@@ -538,12 +539,13 @@ class PortfolioFormatter:
         Get filtered projects (cards).
 
         Args:
+            user_id: The authenticated user's ID
             project_type: Filter by type ('code', 'visual_media', 'text')
             search: Search in project name, description, skills
             min_importance: Minimum importance score
             featured_only: Only return featured projects
         """
-        projects = self.db.get_all_projects(include_hidden=False)
+        projects = self.db.get_all_projects(include_hidden=False, user_id=user_id)
         filtered = projects
 
         if project_type:
@@ -583,11 +585,11 @@ class PortfolioFormatter:
             },
         }
 
-    def export_to_json(self, output_path: str, include_hidden: bool = False) -> str:
+    def export_to_json(self, output_path: str, user_id: int, include_hidden: bool = False) -> str:
         """Export portfolio data to JSON file (includes embedded summary)."""
         import json
 
-        data = self.get_portfolio_data(include_hidden=include_hidden)
+        data = self.get_portfolio_data(user_id=user_id, include_hidden=include_hidden)
         with open(output_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
 
@@ -788,12 +790,12 @@ class PortfolioFormatter:
             cleaned.append(s)
 
         return cleaned[:20]
-    def get_projects_for_summary_input(self, include_hidden: bool = False) -> List[Dict[str, Any]]:
+    def get_projects_for_summary_input(self, user_id: int, include_hidden: bool = False) -> List[Dict[str, Any]]:
         """
         Returns project dicts in the shape summarize_projects() expects.
         Uses ONLY DB fields (no keywords).
         """
-        projects = self.db.get_all_projects(include_hidden=include_hidden)
+        projects = self.db.get_all_projects(include_hidden=include_hidden, user_id=user_id)
 
         out = []
         for p in projects:

--- a/src/Routers/portfolio.py
+++ b/src/Routers/portfolio.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, Query, Body
+from fastapi import APIRouter, HTTPException, Query, Body, Depends
 from pydantic import BaseModel
 from typing import Optional
+from src.Services.auth_service import require_auth
 from src.Services.portfolio_service import (
     get_portfolio,
     get_portfolio_project,
@@ -12,40 +13,69 @@ from src.Services.portfolio_service import (
 
 router = APIRouter(prefix="/portfolio", tags=["Portfolio"])
 
+
 @router.get("")
-def get_portfolio_endpoint(include_hidden: bool = Query(default=False)):
-    """Return full portfolio: all projects, stats, and summary."""
-    return get_portfolio(include_hidden=include_hidden)
+def get_portfolio_endpoint(
+    include_hidden: bool = Query(default=False),
+    user_id: int = Depends(require_auth)
+):
+    """Return the stored portfolio for the authenticated user."""
+    return get_portfolio(user_id=user_id, include_hidden=include_hidden)
 
 
 @router.get("/stats")
-def get_portfolio_stats_endpoint(include_hidden: bool = Query(default=False)):
-    """Return only portfolio-level statistics."""
-    return get_portfolio_stats(include_hidden=include_hidden)
+def get_portfolio_stats_endpoint(
+    include_hidden: bool = Query(default=False),
+    user_id: int = Depends(require_auth)
+):
+    """Return only portfolio-level statistics for the authenticated user."""
+    return get_portfolio_stats(user_id=user_id, include_hidden=include_hidden)
 
 
 @router.get("/summary")
-def get_portfolio_summary_endpoint(include_hidden: bool = Query(default=False)):
-    """Return only the portfolio summary text and highlights."""
-    return get_portfolio_summary(include_hidden=include_hidden)
+def get_portfolio_summary_endpoint(
+    include_hidden: bool = Query(default=False),
+    user_id: int = Depends(require_auth)
+):
+    """Return only the portfolio summary text and highlights for the authenticated user."""
+    return get_portfolio_summary(user_id=user_id, include_hidden=include_hidden)
+
+
+@router.post("/generate")
+def generate_portfolio_endpoint(
+    include_hidden: bool = Query(default=False),
+    user_id: int = Depends(require_auth)
+):
+    """
+    Regenerate the portfolio from current DB state, save it to the user record,
+    and return the fresh data.
+    """
+    return generate_portfolio(user_id=user_id, include_hidden=include_hidden)
 
 
 @router.get("/{project_id}")
-def get_portfolio_project_endpoint(project_id: int):
-    """Return a single project card by ID."""
-    result = get_portfolio_project(project_id)
+def get_portfolio_project_endpoint(
+    project_id: int,
+    user_id: int = Depends(require_auth)
+):
+    """Return a single project card by ID. Only accessible by the project owner."""
+    result = get_portfolio_project(user_id=user_id, project_id=project_id)
     if result is None:
         raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
     return result
 
-@router.post("/generate")
-def generate_portfolio_endpoint():
-    return generate_portfolio()
-
 
 @router.post("/{project_id}/edit")
-def edit_portfolio_project_endpoint(project_id: int, updates: dict = Body(...)):
-    result = edit_portfolio_project(project_id, updates)
+def edit_portfolio_project_endpoint(
+    project_id: int,
+    updates: dict = Body(...),
+    user_id: int = Depends(require_auth)
+):
+    """
+    Edit a project's fields. Only the project owner can edit.
+    Saves the updated portfolio to the user record after editing.
+    """
+    result = edit_portfolio_project(user_id=user_id, project_id=project_id, updates=updates)
     if result is None:
         raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
     return result

--- a/src/Services/portfolio_service.py
+++ b/src/Services/portfolio_service.py
@@ -2,62 +2,123 @@
 Portfolio Service
 ================
 Business logic for portfolio API endpoints.
-Wraps the existing PortfolioService class and database operations.
+Wraps the existing PortfolioFormatter class and database operations.
+
+All functions require a user_id from the authenticated JWT token.
+Portfolio data is persisted to the user.portfolio column after
+generate and edit operations so GET /portfolio can return the
+stored version without recomputing every time.
 """
 
 from typing import Optional, Dict, Any
+from fastapi import HTTPException, status
 from src.Databases.database import db_manager
 from src.Portfolio.portfolioFormatter import PortfolioFormatter
 
 _portfolio_service = PortfolioFormatter()
 
-def get_portfolio(include_hidden: bool = False) -> dict:
-    """Return the full portfolio with all projects, stats, and summary."""
-    return _portfolio_service.get_portfolio_data(include_hidden=include_hidden)
+
+def _save_portfolio_to_user(user_id: int, portfolio_data: dict) -> None:
+    """Persist the full portfolio JSON to the user's record in the users table."""
+    db_manager.update_user(user_id, {'portfolio': portfolio_data})
 
 
-def get_portfolio_project(project_id: int) -> Optional[dict]:
-    """Return a single formatted project card by ID. Returns None if not found."""
+def get_portfolio(user_id: int, include_hidden: bool = False) -> dict:
+    """
+    Return the stored portfolio for the authenticated user.
+    If no portfolio has been generated yet, generate and store it first.
+    """
+    user = db_manager.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Return stored portfolio only for the default (non-hidden) view.
+    # If include_hidden=True, always regenerate fresh so hidden projects
+    # are not filtered out by a previously cached version.
+    if user.portfolio and not include_hidden:
+        return user.portfolio
+
+    # Otherwise generate fresh, save it, and return it
+    portfolio_data = _portfolio_service.get_portfolio_data(
+        user_id=user_id,
+        include_hidden=include_hidden
+    )
+    _save_portfolio_to_user(user_id, portfolio_data)
+    return portfolio_data
+
+
+def get_portfolio_project(user_id: int, project_id: int) -> Optional[dict]:
+    """
+    Return a single formatted project card by ID.
+    Raises 403 if the project does not belong to the authenticated user.
+    Returns None if not found.
+    """
     project = db_manager.get_project(project_id)
     if not project:
         return None
+
+    if project.user_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to view this project"
+        )
+
     return _portfolio_service._format_project_card(project)
 
 
-
-
-def get_portfolio_stats(include_hidden: bool = False) -> dict:
-    """Return only the stats portion of the portfolio."""
-    projects = db_manager.get_all_projects(include_hidden=include_hidden)
+def get_portfolio_stats(user_id: int, include_hidden: bool = False) -> dict:
+    """Return only the stats portion of the portfolio for the authenticated user."""
+    projects = db_manager.get_all_projects(include_hidden=include_hidden, user_id=user_id)
     return _portfolio_service._calculate_portfolio_stats(projects)
 
 
-def get_portfolio_summary(include_hidden: bool = False) -> dict:
-    """Return only the summary portion of the portfolio."""
-    projects = db_manager.get_all_projects(include_hidden=include_hidden)
+def get_portfolio_summary(user_id: int, include_hidden: bool = False) -> dict:
+    """Return only the summary portion of the portfolio for the authenticated user."""
+    projects = db_manager.get_all_projects(include_hidden=include_hidden, user_id=user_id)
     return _portfolio_service._generate_portfolio_summary(projects)
 
 
-def generate_portfolio(include_hidden: bool = False) -> dict:
+def generate_portfolio(user_id: int, include_hidden: bool = False) -> dict:
     """
-    Generate a portfolio from all projects and return the full data.
+    Regenerate the portfolio from current DB state for the authenticated user,
+    save it to user.portfolio, and return the fresh data.
     """
-    return _portfolio_service.get_portfolio_data(include_hidden=include_hidden)
+    user = db_manager.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    portfolio_data = _portfolio_service.get_portfolio_data(
+        user_id=user_id,
+        include_hidden=include_hidden
+    )
+    _save_portfolio_to_user(user_id, portfolio_data)
+    return portfolio_data
 
 
-
-def edit_portfolio_project(project_id: int, updates: Dict[str, Any]) -> Optional[dict]:
+def edit_portfolio_project(user_id: int, project_id: int, updates: Dict[str, Any]) -> Optional[dict]:
     """
-    Edit a project's fields and return the updated formatted project card.
+    Edit a project's fields, regenerate and save the full portfolio,
+    and return the updated formatted project card.
+    Raises 403 if the project does not belong to the authenticated user.
     """
     project = db_manager.get_project(project_id)
     if not project:
         return None
+
+    if project.user_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to edit this project"
+        )
 
     db_manager.update_project(project_id, updates)
 
     updated = db_manager.get_project(project_id)
     if not updated:
         return None
+
+    # Regenerate and persist the full portfolio to keep it in sync
+    portfolio_data = _portfolio_service.get_portfolio_data(user_id=user_id)
+    _save_portfolio_to_user(user_id, portfolio_data)
 
     return _portfolio_service._format_project_card(updated)

--- a/tests/test_API_portfolio.py
+++ b/tests/test_API_portfolio.py
@@ -8,6 +8,7 @@ sys.path.insert(0, project_root)
 from fastapi.testclient import TestClient
 from src.mainAPI import app
 from src.Databases.database import db_manager
+from src.Services.auth_service import create_access_token, hash_password
 
 client = TestClient(app)
 
@@ -20,18 +21,67 @@ def teardown_function():
     db_manager.clear_all_data()
 
 
-def _create_project(project_type="code", name="Test Project"):
+def _create_user(email="test@example.com"):
+    """Create a test user and return (user, auth_headers)."""
+    user = db_manager.create_user({
+        "first_name": "Test",
+        "last_name": "User",
+        "email": email,
+        "password_hash": hash_password("password123"),
+    })
+    token = create_access_token(user.id)
+    headers = {"Authorization": f"Bearer {token}"}
+    return user, headers
+
+
+def _create_project(user_id, project_type="code", name="Test Project"):
+    """Create a test project owned by the given user."""
     project = db_manager.create_project({
         "name": name,
         "file_path": f"/test/{name.replace(' ', '_').lower()}",
         "project_type": project_type,
+        "user_id": user_id,
     })
     return project.id
+
+
+# ── UNAUTHENTICATED REQUESTS ───────────────────────────────────────────────────
+
+def test_get_portfolio_requires_auth():
+    response = client.get("/portfolio")
+    assert response.status_code == 401
+
+
+def test_get_portfolio_stats_requires_auth():
+    response = client.get("/portfolio/stats")
+    assert response.status_code == 401
+
+
+def test_get_portfolio_summary_requires_auth():
+    response = client.get("/portfolio/summary")
+    assert response.status_code == 401
+
+
+def test_get_portfolio_project_requires_auth():
+    response = client.get("/portfolio/1")
+    assert response.status_code == 401
+
+
+def test_generate_portfolio_requires_auth():
+    response = client.post("/portfolio/generate")
+    assert response.status_code == 401
+
+
+def test_edit_portfolio_project_requires_auth():
+    response = client.post("/portfolio/1/edit", json={"is_featured": True})
+    assert response.status_code == 401
+
 
 # ── GET /portfolio ─────────────────────────────────────────────────────────────
 
 def test_get_portfolio_empty():
-    response = client.get("/portfolio")
+    _, headers = _create_user()
+    response = client.get("/portfolio", headers=headers)
     assert response.status_code == 200
     data = response.json()
     assert data["total_projects"] == 0
@@ -39,9 +89,10 @@ def test_get_portfolio_empty():
 
 
 def test_get_portfolio_with_projects():
-    _create_project(name="Project A")
-    _create_project(name="Project B")
-    response = client.get("/portfolio")
+    user, headers = _create_user()
+    _create_project(user.id, name="Project A")
+    _create_project(user.id, name="Project B")
+    response = client.get("/portfolio", headers=headers)
     assert response.status_code == 200
     data = response.json()
     assert data["total_projects"] == 2
@@ -52,37 +103,57 @@ def test_get_portfolio_with_projects():
 
 
 def test_get_portfolio_excludes_hidden_by_default():
-    pid = _create_project(name="Hidden Project")
-    client.post(f"/portfolio/{pid}/edit", json={"is_hidden": True})
+    user, headers = _create_user()
+    pid = _create_project(user.id, name="Hidden Project")
+    client.post(f"/portfolio/{pid}/edit", json={"is_hidden": True}, headers=headers)
 
-    response = client.get("/portfolio")
+    response = client.get("/portfolio", headers=headers)
     data = response.json()
     names = [p["name"] for p in data["projects"]]
     assert "Hidden Project" not in names
 
 
 def test_get_portfolio_include_hidden():
-    pid = _create_project(name="Hidden Project")
-    client.post(f"/portfolio/{pid}/edit", json={"is_hidden": True})
+    user, headers = _create_user()
+    pid = _create_project(user.id, name="Hidden Project")
+    client.post(f"/portfolio/{pid}/edit", json={"is_hidden": True}, headers=headers)
 
-    response = client.get("/portfolio?include_hidden=true")
+    response = client.get("/portfolio?include_hidden=true", headers=headers)
     data = response.json()
     names = [p["name"] for p in data["projects"]]
     assert "Hidden Project" in names
 
 
+def test_get_portfolio_only_shows_own_projects():
+    """User A should not see User B's projects."""
+    user_a, headers_a = _create_user(email="usera@example.com")
+    user_b, headers_b = _create_user(email="userb@example.com")
+
+    _create_project(user_a.id, name="User A Project")
+    _create_project(user_b.id, name="User B Project")
+
+    response = client.get("/portfolio", headers=headers_a)
+    data = response.json()
+    names = [p["name"] for p in data["projects"]]
+    assert "User A Project" in names
+    assert "User B Project" not in names
+
+
 # ── GET /portfolio/stats ───────────────────────────────────────────────────────
 
 def test_get_portfolio_stats_empty():
-    response = client.get("/portfolio/stats")
+    _, headers = _create_user()
+    response = client.get("/portfolio/stats", headers=headers)
     assert response.status_code == 200
     data = response.json()
     assert data["total_projects"] == 0
 
+
 def test_get_portfolio_stats_with_projects():
-    _create_project(project_type="code", name="Code Project")
-    _create_project(project_type="text", name="Text Project")
-    response = client.get("/portfolio/stats")
+    user, headers = _create_user()
+    _create_project(user.id, project_type="code", name="Code Project")
+    _create_project(user.id, project_type="text", name="Text Project")
+    response = client.get("/portfolio/stats", headers=headers)
     assert response.status_code == 200
     data = response.json()
     assert data["total_projects"] == 2
@@ -93,7 +164,8 @@ def test_get_portfolio_stats_with_projects():
 # ── GET /portfolio/summary ─────────────────────────────────────────────────────
 
 def test_get_portfolio_summary_empty():
-    response = client.get("/portfolio/summary")
+    _, headers = _create_user()
+    response = client.get("/portfolio/summary", headers=headers)
     assert response.status_code == 200
     data = response.json()
     assert "text" in data
@@ -101,8 +173,9 @@ def test_get_portfolio_summary_empty():
 
 
 def test_get_portfolio_summary_with_projects():
-    _create_project(name="Cool Project")
-    response = client.get("/portfolio/summary")
+    user, headers = _create_user()
+    _create_project(user.id, name="Cool Project")
+    response = client.get("/portfolio/summary", headers=headers)
     assert response.status_code == 200
     data = response.json()
     assert data["text"] != ""
@@ -111,45 +184,67 @@ def test_get_portfolio_summary_with_projects():
 # ── GET /portfolio/{project_id} ────────────────────────────────────────────────
 
 def test_get_portfolio_project_success():
-    pid = _create_project(name="My Project")
-    response = client.get(f"/portfolio/{pid}")
+    user, headers = _create_user()
+    pid = _create_project(user.id, name="My Project")
+    response = client.get(f"/portfolio/{pid}", headers=headers)
     assert response.status_code == 200
     data = response.json()
     assert data["name"] == "My Project"
 
 
 def test_get_portfolio_project_not_found():
-    response = client.get("/portfolio/99999")
+    _, headers = _create_user()
+    response = client.get("/portfolio/99999", headers=headers)
     assert response.status_code == 404
 
 
 def test_get_portfolio_project_invalid_id():
-    response = client.get("/portfolio/abc")
+    _, headers = _create_user()
+    response = client.get("/portfolio/abc", headers=headers)
     assert response.status_code == 422
+
+
+def test_get_portfolio_project_forbidden_for_other_user():
+    """User B should not be able to view User A's project."""
+    user_a, _ = _create_user(email="usera@example.com")
+    _, headers_b = _create_user(email="userb@example.com")
+
+    pid = _create_project(user_a.id, name="User A Private Project")
+    response = client.get(f"/portfolio/{pid}", headers=headers_b)
+    assert response.status_code == 403
 
 
 # ── POST /portfolio/generate ───────────────────────────────────────────────────
 
-def test_generate_portfolio_returns_message_or_portfolio():
-    _create_project(name="Gen Project")
+def test_generate_portfolio_returns_portfolio():
+    user, headers = _create_user()
+    _create_project(user.id, name="Gen Project")
 
-    response = client.post("/portfolio/generate")
+    response = client.post("/portfolio/generate", headers=headers)
     assert response.status_code == 200
-
     data = response.json()
+    assert "projects" in data
+    assert "summary" in data
+    assert "stats" in data
 
-    if "message" in data:
-        assert data["message"].lower().startswith("portfolio")
-    else:
-        assert "projects" in data
-        assert "summary" in data
-        assert "stats" in data
+
+def test_generate_portfolio_saves_to_user():
+    """After generating, the portfolio should be persisted on the user record."""
+    user, headers = _create_user()
+    _create_project(user.id, name="Saved Project")
+
+    client.post("/portfolio/generate", headers=headers)
+
+    updated_user = db_manager.get_user(user.id)
+    assert updated_user.portfolio is not None
+    assert "projects" in updated_user.portfolio
 
 
 # ── POST /portfolio/{project_id}/edit ──────────────────────────────────────────
 
 def test_edit_portfolio_project_success():
-    pid = _create_project(name="Editable Project")
+    user, headers = _create_user()
+    pid = _create_project(user.id, name="Editable Project")
 
     response = client.post(
         f"/portfolio/{pid}/edit",
@@ -159,6 +254,7 @@ def test_edit_portfolio_project_success():
             "importance_score": 0.9,
             "custom_description": "Updated via edit endpoint",
         },
+        headers=headers,
     )
     assert response.status_code == 200
     data = response.json()
@@ -174,35 +270,61 @@ def test_edit_portfolio_project_success():
 
 
 def test_edit_portfolio_project_not_found():
-    response = client.post("/portfolio/99999/edit", json={"is_featured": True})
+    _, headers = _create_user()
+    response = client.post("/portfolio/99999/edit", json={"is_featured": True}, headers=headers)
     assert response.status_code == 404
 
 
 def test_edit_portfolio_project_invalid_id():
-    response = client.post("/portfolio/abc/edit", json={"is_featured": True})
+    _, headers = _create_user()
+    response = client.post("/portfolio/abc/edit", json={"is_featured": True}, headers=headers)
     assert response.status_code == 422
 
 
 def test_edit_portfolio_project_empty_body():
-    pid = _create_project()
-    response = client.post(f"/portfolio/{pid}/edit", json={})
+    user, headers = _create_user()
+    pid = _create_project(user.id)
+    response = client.post(f"/portfolio/{pid}/edit", json={}, headers=headers)
     assert response.status_code in (200, 400)
 
 
-def test_edit_portfolio_project_hides_from_default_portfolio():
-    pid = _create_project(name="Hidden via Edit")
+def test_edit_portfolio_project_forbidden_for_other_user():
+    """User B should not be able to edit User A's project."""
+    user_a, _ = _create_user(email="usera@example.com")
+    _, headers_b = _create_user(email="userb@example.com")
 
-    response = client.post(f"/portfolio/{pid}/edit", json={"is_hidden": True})
+    pid = _create_project(user_a.id, name="User A Project")
+    response = client.post(f"/portfolio/{pid}/edit", json={"is_featured": True}, headers=headers_b)
+    assert response.status_code == 403
+
+
+def test_edit_portfolio_project_hides_from_default_portfolio():
+    user, headers = _create_user()
+    pid = _create_project(user.id, name="Hidden via Edit")
+
+    response = client.post(f"/portfolio/{pid}/edit", json={"is_hidden": True}, headers=headers)
     assert response.status_code == 200
 
-    response = client.get("/portfolio")
+    response = client.get("/portfolio", headers=headers)
     assert response.status_code == 200
     data = response.json()
     names = [p["name"] for p in data["projects"]]
     assert "Hidden via Edit" not in names
 
-    response = client.get("/portfolio?include_hidden=true")
+    response = client.get("/portfolio?include_hidden=true", headers=headers)
     assert response.status_code == 200
     data = response.json()
     names = [p["name"] for p in data["projects"]]
     assert "Hidden via Edit" in names
+
+
+def test_edit_portfolio_project_saves_portfolio_to_user():
+    """After editing, the updated portfolio should be persisted on the user record."""
+    user, headers = _create_user()
+    pid = _create_project(user.id, name="Edit Saves Portfolio")
+
+    client.post(f"/portfolio/{pid}/edit", json={"is_featured": True}, headers=headers)
+
+    updated_user = db_manager.get_user(user.id)
+    assert updated_user.portfolio is not None
+    assert "projects" in updated_user.portfolio

--- a/tests/test_portfolioFormatter.py
+++ b/tests/test_portfolioFormatter.py
@@ -33,7 +33,21 @@ class TestPortfolioFormatter:
         
         # Clear existing test data
         cls.cleanup_test_data()
-        
+
+        # Create a test user for ownership (reuse if already exists)
+        from src.Services.auth_service import hash_password
+        existing_user = db_manager.get_user_by_email('formatter_test@example.com')
+        if existing_user:
+            cls.test_user = existing_user
+        else:
+            cls.test_user = db_manager.create_user({
+                'first_name': 'Test',
+                'last_name': 'User',
+                'email': 'formatter_test@example.com',
+                'password_hash': hash_password('password123'),
+            })
+        cls.user_id = cls.test_user.id
+
         # Create sample projects
         cls.test_projects = []
         
@@ -55,7 +69,8 @@ class TestPortfolioFormatter:
             'is_featured': True,
             'date_created': datetime(2024, 1, 15, tzinfo=timezone.utc),
             'date_modified': datetime(2024, 3, 20, tzinfo=timezone.utc),
-            'collaboration_type': 'Collaborative Project'
+            'collaboration_type': 'Collaborative Project',
+            'user_id': cls.user_id,
         }
         project1 = db_manager.create_project(project1_data)
         cls.test_projects.append(project1)
@@ -91,7 +106,8 @@ class TestPortfolioFormatter:
             'importance_score': 72.0,
             'is_featured': False,
             'date_created': datetime(2024, 2, 1, tzinfo=timezone.utc),
-            'date_modified': datetime(2024, 2, 28, tzinfo=timezone.utc)
+            'date_modified': datetime(2024, 2, 28, tzinfo=timezone.utc),
+            'user_id': cls.user_id,
         }
         project2 = db_manager.create_project(project2_data)
         cls.test_projects.append(project2)
@@ -110,7 +126,8 @@ class TestPortfolioFormatter:
             'importance_score': 90.0,
             'is_featured': True,
             'date_created': datetime(2024, 1, 5, tzinfo=timezone.utc),
-            'date_modified': datetime(2024, 1, 25, tzinfo=timezone.utc)
+            'date_modified': datetime(2024, 1, 25, tzinfo=timezone.utc),
+            'user_id': cls.user_id,
         }
         project3 = db_manager.create_project(project3_data)
         cls.test_projects.append(project3)
@@ -123,7 +140,8 @@ class TestPortfolioFormatter:
             'lines_of_code': 500,
             'file_count': 5,
             'languages': ['Python'],
-            'importance_score': 35.0
+            'importance_score': 35.0,
+            'user_id': cls.user_id,
         }
         project4 = db_manager.create_project(project4_data)
         cls.test_projects.append(project4)
@@ -309,7 +327,7 @@ class TestPortfolioFormatter:
         """Test complete portfolio data generation"""
         formatter = PortfolioFormatter()
         
-        portfolio = formatter.get_portfolio_data()
+        portfolio = formatter.get_portfolio_data(user_id=self.user_id)
         
         # Check structure
         assert 'summary' in portfolio
@@ -363,17 +381,17 @@ class TestPortfolioFormatter:
         formatter = PortfolioFormatter()
         fixture_ids = {p.id for p in self.test_projects}
 
-        code_projects = formatter.get_filtered_projects(project_type='code')
+        code_projects = formatter.get_filtered_projects(user_id=self.user_id, project_type='code')
         fixture_code = [p for p in code_projects['projects'] if p['id'] in fixture_ids]
         assert len(fixture_code) == 2
         assert all(p['type'] == 'code' for p in fixture_code)
 
-        media_projects = formatter.get_filtered_projects(project_type='visual_media')
+        media_projects = formatter.get_filtered_projects(user_id=self.user_id, project_type='visual_media')
         fixture_media = [p for p in media_projects['projects'] if p['id'] in fixture_ids]
         assert len(fixture_media) == 1
         assert fixture_media[0]['type'] == 'visual_media'
 
-        text_projects = formatter.get_filtered_projects(project_type='text')
+        text_projects = formatter.get_filtered_projects(user_id=self.user_id, project_type='text')
         fixture_text = [p for p in text_projects['projects'] if p['id'] in fixture_ids]
         assert len(fixture_text) == 1
         assert fixture_text[0]['type'] == 'text'
@@ -384,15 +402,15 @@ class TestPortfolioFormatter:
         formatter = PortfolioFormatter()
         
         # Search for "research"
-        results = formatter.get_filtered_projects(search='research')
+        results = formatter.get_filtered_projects(user_id=self.user_id, search='research')
         assert results['total'] >= 1
         
         # Search for "platform"
-        results = formatter.get_filtered_projects(search='platform')
+        results = formatter.get_filtered_projects(user_id=self.user_id, search='platform')
         assert results['total'] >= 1
         
         # Search for non-existent term
-        results = formatter.get_filtered_projects(search='nonexistentxyz')
+        results = formatter.get_filtered_projects(user_id=self.user_id, search='nonexistentxyz')
         assert results['total'] == 0
         
         print("✓ Search filtering test passed")
@@ -402,11 +420,11 @@ class TestPortfolioFormatter:
         formatter = PortfolioFormatter()
         
         # Filter for high importance (>= 80)
-        high_importance = formatter.get_filtered_projects(min_importance=80)
+        high_importance = formatter.get_filtered_projects(user_id=self.user_id, min_importance=80)
         assert all(p['importance_score'] >= 80 for p in high_importance['projects'])
         
         # Filter for medium importance (>= 50)
-        medium_importance = formatter.get_filtered_projects(min_importance=50)
+        medium_importance = formatter.get_filtered_projects(user_id=self.user_id, min_importance=50)
         assert len(medium_importance['projects']) >= len(high_importance['projects'])
         
         print("✓ Importance filtering test passed")
@@ -415,7 +433,7 @@ class TestPortfolioFormatter:
         formatter = PortfolioFormatter()
         fixture_ids = {p.id for p in self.test_projects}
 
-        featured = formatter.get_filtered_projects(featured_only=True)
+        featured = formatter.get_filtered_projects(user_id=self.user_id, featured_only=True)
         fixture_featured = [p for p in featured['projects'] if p['id'] in fixture_ids]
 
         assert all(p['is_featured'] for p in fixture_featured)
@@ -428,6 +446,7 @@ class TestPortfolioFormatter:
         
         # Code projects with importance >= 70
         results = formatter.get_filtered_projects(
+            user_id=self.user_id,
             project_type='code',
             min_importance=70
         )
@@ -436,6 +455,7 @@ class TestPortfolioFormatter:
         
         # Featured code projects
         results = formatter.get_filtered_projects(
+            user_id=self.user_id,
             project_type='code',
             featured_only=True
         )
@@ -466,7 +486,7 @@ class TestPortfolioFormatter:
     def test_generate_portfolio_summary(self):
         """Test portfolio summary generation"""
         formatter = PortfolioFormatter()
-        projects = db_manager.get_all_projects()
+        projects = db_manager.get_all_projects(user_id=self.user_id)
         
         summary = formatter._generate_portfolio_summary(projects)
         
@@ -498,7 +518,7 @@ class TestPortfolioFormatter:
         
         try:
             # Export to JSON
-            result_path = formatter.export_to_json(temp_path)
+            result_path = formatter.export_to_json(temp_path, user_id=self.user_id)
             
             assert os.path.exists(result_path)
             
@@ -539,7 +559,7 @@ class TestPortfolioFormatter:
                 pass
         
         formatter = PortfolioFormatter()
-        portfolio = formatter.get_portfolio_data()
+        portfolio = formatter.get_portfolio_data(user_id=self.user_id)
         
         # Recreate test projects
         self.__class__.setup_class()
@@ -575,7 +595,8 @@ class TestPortfolioFormatter:
             'name': 'Test No Dates',
             'file_path': '/test/path/nodates',
             'project_type': 'code',
-            'file_count': 10
+            'file_count': 10,
+            'user_id': self.user_id,
         }
         project = db_manager.create_project(project_data)
         


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

All portfolio endpoints now require authentication and only creates/retrieves/edits portfolio item for specific user IDs. to test manually, start the uvicorn server (python3 -m uvicorn src.mainAPI:app --reload) and sign up or log in using auth endpoints. After a successful sign up/log in, copy the token from the http response body. Scroll all the way up, locate the Authorize button on the top right, paste the token there and click 'authorize' to actually login. Now test out the portfolio endpoints. Without completing these steps, the portfolio endpoints should only return 'authentication required' in the http body. Details about these changes are below. **From this point on any changes or additions to the portfolio endpoint should always take authentication into account.**

- portfolioFormatter.py

  - Added user_id to get_portfolio_data(), get_filtered_projects(), get_projects_for_summary_input(), and export_to_json() — all pass it to get_all_projects() to scope queries to the authenticated user

- portfolio_service.py

  - Added user_id to every function and a _save_portfolio_to_user() helper to persist portfolio JSON to the users table
get_portfolio() returns cached user.portfolio if available, otherwise generates and saves it; generate_portfolio() always regenerates fresh and saves
Added ownership checks (403) to get_portfolio_project() and edit_portfolio_project(); edit also regenerates and saves the portfolio after updating

- portfolio.py

  - Added require_auth to every endpoint (401 for guests), passed user_id to all service calls, and moved POST /generate above GET /{project_id} to avoid route conflicts

- test_API_portfolio.py

  - Added _create_user() helper, updated _create_project() to assign user_id, added 11 new tests covering 401s, 403s, user isolation, and portfolio persistence, and fixed a bug where include_hidden=true returned empty due to cached portfolio being served

- test_portfolioFormatter.py

  - Added test user creation with an email uniqueness guard, added user_id to all test project dicts, and updated all formatter method calls to pass user_id

**Closes:** #398 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing
- [x] test_API_portfolio.py
- [x] test_portfolioFormatter.py
- [x] manual testing as well

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
