### PR TITLE
Add frontend tests for Evidence and Resumes pages

### DIFF
--- a/artifactMining/src/tests/Evidence.test.jsx
+++ b/artifactMining/src/tests/Evidence.test.jsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Evidence from "../pages/Evidence";
+
+vi.mock("../apiClient", () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from "../apiClient";
+
+const SAMPLE_PROJECTS = [
+  { id: 1, name: "Alpha", project_type: "code" },
+  { id: 2, name: "Beta", project_type: "data" },
+];
+
+const SAMPLE_EVIDENCE = {
+  test_coverage: 85,
+  code_quality: "A",
+  manual_metrics: { Users: { value: "1000", description: "Active users" } },
+  feedback: [{ text: "Great work", source: "Client", rating: 5 }],
+  achievements: [{ description: "Won hackathon", date: "2024-01-01" }],
+  readme_badges: [],
+};
+
+function setupMocks({ evidence = SAMPLE_EVIDENCE } = {}) {
+  apiFetch.mockImplementation((url, opts) => {
+    if (url === "/projects") return Promise.resolve(SAMPLE_PROJECTS);
+    if (url.match(/\/evidence\/\d+$/) && (!opts || opts.method !== "DELETE"))
+      return Promise.resolve(evidence);
+    if (url.includes("/evidence/") && url.includes("/extract"))
+      return Promise.resolve({});
+    if (url.includes("/evidence/") && url.includes("/metric"))
+      return Promise.resolve({});
+    if (url.includes("/evidence/") && url.includes("/feedback"))
+      return Promise.resolve({});
+    if (url.includes("/evidence/") && url.includes("/achievement"))
+      return Promise.resolve({});
+    if (url.match(/\/evidence\/\d+$/) && opts?.method === "DELETE")
+      return Promise.resolve({});
+    return Promise.reject(new Error("Unmatched: " + url));
+  });
+}
+
+function renderEvidence() {
+  return render(
+    <MemoryRouter>
+      <Evidence />
+    </MemoryRouter>
+  );
+}
+
+function clickEvTab(label) {
+  const tabs = screen.getAllByRole("button").filter(
+    b => b.className.includes("ev-tab") && b.textContent.includes(label)
+  );
+  fireEvent.click(tabs[0]);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("Evidence - rendering", () => {
+  beforeEach(() => setupMocks());
+
+  it("renders Evidence Manager heading", async () => {
+    renderEvidence();
+    await waitFor(() => expect(screen.getByText("Evidence Manager")).toBeTruthy());
+  });
+
+  it("renders project list", async () => {
+    renderEvidence();
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeTruthy());
+  });
+
+  it("shows select prompt before project is chosen", async () => {
+    renderEvidence();
+    await waitFor(() =>
+      expect(screen.getByText(/Select a project to manage evidence/i)).toBeTruthy()
+    );
+  });
+});
+
+describe("Evidence - project selection", () => {
+  beforeEach(() => setupMocks());
+
+  it("loads evidence when a project is clicked", async () => {
+    renderEvidence();
+    await waitFor(() => screen.getByText("Alpha"));
+    fireEvent.click(screen.getByText("Alpha").closest(".ev-proj-row"));
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledWith("/evidence/1"));
+  });
+
+  it("renders evidence tabs after project selected", async () => {
+    renderEvidence();
+    await waitFor(() => screen.getByText("Alpha"));
+    fireEvent.click(screen.getByText("Alpha").closest(".ev-proj-row"));
+    await waitFor(() => {
+      const tabs = screen.getAllByRole("button").filter(b => b.className.includes("ev-tab") && b.textContent === "View");
+      expect(tabs.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows test coverage after loading evidence", async () => {
+    renderEvidence();
+    await waitFor(() => screen.getByText("Alpha"));
+    fireEvent.click(screen.getByText("Alpha").closest(".ev-proj-row"));
+    await waitFor(() => expect(screen.getByText("85%")).toBeTruthy());
+  });
+
+  it("shows feedback text in view tab", async () => {
+    renderEvidence();
+    await waitFor(() => screen.getByText("Alpha"));
+    fireEvent.click(screen.getByText("Alpha").closest(".ev-proj-row"));
+    await waitFor(() => expect(screen.getByText(/Great work/i)).toBeTruthy());
+  });
+
+  it("shows achievement in view tab", async () => {
+    renderEvidence();
+    await waitFor(() => screen.getByText("Alpha"));
+    fireEvent.click(screen.getByText("Alpha").closest(".ev-proj-row"));
+    await waitFor(() => expect(screen.getByText(/Won hackathon/i)).toBeTruthy());
+  });
+});
+
+describe("Evidence - tab switching", () => {
+  beforeEach(() => setupMocks());
+
+  async function selectProject() {
+    renderEvidence();
+    await waitFor(() => screen.getByText("Alpha"));
+    fireEvent.click(screen.getByText("Alpha").closest(".ev-proj-row"));
+    await waitFor(() =>
+      screen.getAllByRole("button").filter(b => b.className.includes("ev-tab")).length > 0
+    );
+  }
+
+  it("switches to Metric tab", async () => {
+    await selectProject();
+    clickEvTab("Metric");
+    await waitFor(() => expect(screen.getByText("Add Manual Metric")).toBeTruthy());
+  });
+
+  it("switches to Feedback tab", async () => {
+    await selectProject();
+    const feedbackTab = screen.getAllByRole("button").find(
+      b => b.className.includes("ev-tab") && b.textContent.trim() === "+ Feedback"
+    );
+    fireEvent.click(feedbackTab);
+    await waitFor(() => {
+      // Use getAllByText since "Add Feedback" appears in both h3 and button
+      expect(screen.getAllByText(/Add Feedback/i).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("switches to Achievement tab", async () => {
+    await selectProject();
+    const achieveTab = screen.getAllByRole("button").find(
+      b => b.className.includes("ev-tab") && b.textContent.trim() === "+ Achievement"
+    );
+    fireEvent.click(achieveTab);
+    await waitFor(() => {
+      // Use getAllByText since "Add Achievement" appears in both h3 and button
+      expect(screen.getAllByText(/Add Achievement/i).length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("Evidence - form validation", () => {
+  beforeEach(() => setupMocks());
+
+  async function goToMetricTab() {
+    renderEvidence();
+    await waitFor(() => screen.getByText("Alpha"));
+    fireEvent.click(screen.getByText("Alpha").closest(".ev-proj-row"));
+    await waitFor(() =>
+      screen.getAllByRole("button").filter(b => b.className.includes("ev-tab")).length > 0
+    );
+    clickEvTab("Metric");
+    await waitFor(() => screen.getByText("Add Manual Metric"));
+  }
+
+  it("shows error when adding metric without required fields", async () => {
+    await goToMetricTab();
+    fireEvent.click(screen.getByText("Add Metric"));
+    await waitFor(() =>
+      expect(screen.getByText(/Name and value required/i)).toBeTruthy()
+    );
+  });
+});
+
+describe("Evidence - empty state", () => {
+  it("shows no evidence message when evidence is empty", async () => {
+    setupMocks({ evidence: {} });
+    renderEvidence();
+    await waitFor(() => screen.getByText("Alpha"));
+    fireEvent.click(screen.getByText("Alpha").closest(".ev-proj-row"));
+    await waitFor(() =>
+      expect(screen.getByText(/No evidence yet/i)).toBeTruthy()
+    );
+  });
+});
+
+describe("Evidence - API calls", () => {
+  beforeEach(() => setupMocks());
+
+  it("calls /projects on mount", async () => {
+    renderEvidence();
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledWith("/projects"));
+  });
+});

--- a/artifactMining/src/tests/Resumes.test.jsx
+++ b/artifactMining/src/tests/Resumes.test.jsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Resumes from "../pages/Resumes";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+vi.mock("canvas-confetti", () => ({ default: vi.fn() }));
+vi.mock("../components/Toast", () => ({ toast: vi.fn() }));
+
+function setupAuthMocks() {
+  mockFetch.mockImplementation((url) => {
+    if (url.includes("/auth/me")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ id: 1, email: "jane@example.com" }),
+      });
+    }
+    if (url.includes("/consent/ai-consent-status")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ granted: false }) });
+    }
+    if (url.includes("/education")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ education: [] }) });
+    }
+    if (url.includes("/work-history")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ work_history: [] }) });
+    }
+    if (url.includes("/skills/")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ skills: [] }) });
+    }
+    if (url.includes("/resume")) {
+      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+beforeEach(() => {
+  localStorage.setItem("token", "fake-token");
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  localStorage.removeItem("token");
+  mockFetch.mockReset();
+});
+
+function renderResumes() {
+  return render(
+    <MemoryRouter>
+      <Resumes />
+    </MemoryRouter>
+  );
+}
+
+describe("Resumes - authenticated state", () => {
+  beforeEach(() => setupAuthMocks());
+
+  it("renders the page without crashing", async () => {
+    renderResumes();
+    await waitFor(() => expect(document.body).toBeTruthy());
+  });
+
+  it("calls /auth/me on mount", async () => {
+    renderResumes();
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/auth/me"),
+        expect.anything()
+      )
+    );
+  });
+
+  it("calls /resume endpoint after auth", async () => {
+    renderResumes();
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/resume"),
+        expect.anything()
+      )
+    );
+  });
+
+  it("renders Resume Controls heading when authenticated", async () => {
+    renderResumes();
+    await waitFor(() => expect(screen.getByText("Resume Controls")).toBeTruthy());
+  });
+
+  it("shows empty state when no resume exists", async () => {
+    renderResumes();
+    await waitFor(() =>
+      expect(screen.getByText(/No resume yet/i)).toBeTruthy()
+    );
+  });
+
+  it("renders bullet count stepper", async () => {
+    renderResumes();
+    await waitFor(() => expect(screen.getByText("Bullets per project")).toBeTruthy());
+  });
+});
+
+describe("Resumes - unauthenticated state", () => {
+  it("shows sign in prompt when not authenticated", async () => {
+    localStorage.removeItem("token");
+    mockFetch.mockImplementation((url) => {
+      if (url.includes("/auth/me"))
+        return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({}) });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    renderResumes();
+    await waitFor(() =>
+      expect(document.body.innerHTML).toContain("Sign In"), { timeout: 3000 }
+    );
+  });
+
+  it("shows Resume Builder heading on auth wall", async () => {
+    localStorage.removeItem("token");
+    mockFetch.mockImplementation((url) => {
+      if (url.includes("/auth/me"))
+        return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({}) });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    renderResumes();
+    await waitFor(() =>
+      expect(screen.getByText("Resume Builder")).toBeTruthy(), { timeout: 3000 }
+    );
+  });
+});
+
+describe("Resumes - API calls", () => {
+  beforeEach(() => setupAuthMocks());
+
+  it("calls /education endpoint", async () => {
+    renderResumes();
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/education"),
+        expect.anything()
+      )
+    );
+  });
+
+  it("calls /work-history endpoint", async () => {
+    renderResumes();
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/work-history"),
+        expect.anything()
+      )
+    );
+  });
+});


### PR DESCRIPTION
## 📝 Description
Adds frontend unit tests for the Evidence and Resumes pages using Vitest and React Testing Library. Tests cover project selection, tab navigation, form validation, API call verification, authenticated and unauthenticated states.

**Closes:** #551  #552 
---

## 🔧 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing
> **Note:** Ensure you have `jsdom@24` installed:
> ```bash
> cd artifactMining
> npm install jsdom@24 --save-dev
> ```

Then run:
```bash
npx vitest run src/tests/Evidence.test.jsx src/tests/Resumes.test.jsx
```

- [x] `Evidence.test.jsx` — covers project selection, evidence tab switching, form validation, empty states, and API calls.
- [x] `Resumes.test.jsx` — covers authenticated and unauthenticated states, page controls, and API call verification.

---

## ✓ Checklist
- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile